### PR TITLE
remove trailing slash in the server info

### DIFF
--- a/options.js
+++ b/options.js
@@ -11,12 +11,17 @@ $( document ).ready(function() {
     // $("#like").prop('checked', true);
 });
 
+// right strip slash character from url
+function rstripslash(url) {
+    return url.replace(/\/$/, "");
+}
+
 // Saves options to chrome.storage.sync.
 function save_options() {
   $("#status").text('Saving');
   // var color = document.getElementById('color').value;
   // var likesColor = document.getElementById('like').checked;
-  var jiraServer =  $("#jiraServer").val();
+  var jiraServer =  rstripslash($("#jiraServer").val());
   chrome.storage.sync.set({
     jiraServer: jiraServer
   }, function() {


### PR DESCRIPTION
Fixed #1 : If server info has trailing "/", extension does not
work. Added a function called rstripslash that right strips the
slash in the given url. The return value of the function is then
saved as the JiraServer.
